### PR TITLE
prepare MPS support

### DIFF
--- a/openpifpafwebdemo/handlers/feed.py
+++ b/openpifpafwebdemo/handlers/feed.py
@@ -12,8 +12,8 @@ LOG = logging.getLogger(__name__)
 
 class Feed(tornado.web.RequestHandler):
     async def _event(self, name, data):
-        self.write('event: {}\n'.format(name))
-        self.write('data: {}\n\n'.format(data))
+        self.write(f'event: {name}\n')
+        self.write(f'data: {data}\n\n')
         await self.flush()
 
     async def get(self):
@@ -34,7 +34,7 @@ class Feed(tornado.web.RequestHandler):
             return
         await self._event('channel', channel_id)
 
-        channel_name = 'channel:{}'.format(channel_id)
+        channel_name = f'channel:{channel_id}'
         LOG.info('subscribing to %s', channel_name)
         async for json_data in self.application.signal.subscribe(channel_name):
             try:

--- a/openpifpafwebdemo/handlers/human_poses.py
+++ b/openpifpafwebdemo/handlers/human_poses.py
@@ -36,7 +36,7 @@ class HumanPoses(tornado.web.RequestHandler):
         out_data['channel'] = channel_id
         await self.finish(json.dumps(out_data))
 
-        channel_name = 'channel:{}'.format(channel_id)
+        channel_name = f'channel:{channel_id}'
         LOG.info('publishing to %s', channel_name)
         self.application.signal.emit(channel_name, out_data)
 

--- a/openpifpafwebdemo/server.py
+++ b/openpifpafwebdemo/server.py
@@ -128,10 +128,8 @@ def main():
     tornado.autoreload.watch('openpifpafwebdemo/static/clientside.js')
 
     if LOG.getEffectiveLevel() == logging.DEBUG:
-        version = '{}-{}'.format(
-            __version__,
-            ''.join(random.choices(string.ascii_lowercase + string.digits, k=4))
-        )
+        random_suffix = ''.join(random.choices(string.ascii_lowercase + string.digits, k=4))
+        version = f'{__version__}-{random_suffix}'
     else:
         version = __version__
 

--- a/openpifpafwebdemo/server.py
+++ b/openpifpafwebdemo/server.py
@@ -46,8 +46,8 @@ def cli():
     openpifpaf.logger.cli(parser)
     openpifpaf.network.Factory.cli(parser)
 
-    parser.add_argument('--disable-cuda', action='store_true',
-                        help='disable CUDA')
+    parser.add_argument('--force-cpu', action='store_true',
+                        help='disable any acceleration that might be available')
     parser.add_argument('--resolution', default=0.4, type=float,
                         help=('Resolution prescale factor from 640x480. '
                               'Will be rounded to multiples of 16.'))
@@ -92,8 +92,12 @@ def cli():
 
     # add args.device
     args.device = torch.device('cpu')
-    if not args.disable_cuda and torch.cuda.is_available():
-        args.device = torch.device('cuda')
+    if not args.force_cpu:
+        if torch.cuda.is_available():
+            args.device = torch.device('cuda')
+        if hasattr(torch.backends, 'mps') and torch.backends.mps.is_available():
+            args.device = torch.device('mps')
+    LOG.info('Using device "%s".', args.device)
 
     return args
 


### PR DESCRIPTION
Metal Performance Shader (MPS) support is available in nightly builds of PyTorch now.

OpenPifPaf models don't work yet, but an issue is filed here: https://github.com/pytorch/pytorch/issues/77764#issuecomment-1139697313